### PR TITLE
Remove upper bound on time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "0.2.0", features = ["rt-threaded", "io-driver", "time"] }
 tower-make = "0.3"
 tower-service = "0.3"
 zipf = "6.0.0"
-time = ">= 0.2, < 0.2.8" # workaround for https://github.com/Alexhuszagh/rust-lexical/issues/38
+time = "0.2"
 
 clap = { version = "2.25.0", optional = true }
 cookie = { version = "0.13", optional = true }


### PR DESCRIPTION
The original reason for this (the linked issue) doesn't appear to be an
issue, and older versions of time are subject to a rustsec advisory:
https://rustsec.org/advisories/RUSTSEC-2020-0071